### PR TITLE
Basic generic filter.oiexp 11

### DIFF
--- a/src/main/java/fr/jmmc/oiexplorer/ExportUtils.java
+++ b/src/main/java/fr/jmmc/oiexplorer/ExportUtils.java
@@ -126,7 +126,7 @@ public final class ExportUtils {
                 for (String subsetId : ocm.getSubsetDefinitionIds()) {
                     final SubsetDefinition subsetDefinition = ocm.getSubsetDefinitionRef(subsetId);
                     if (subsetDefinition != null) {
-                        if (subsetDefinition.getOIFitsSubset() != null) {
+                        if (subsetDefinition.getSelectorResult()!= null) {
                             noData = false;
                         } else {
                             logger.warn("Subset[{}] has no data with filter {}", subsetId, subsetDefinition.getFilter());

--- a/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.form
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Form version="1.3" maxVersion="1.8" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+<Form version="1.8" maxVersion="1.8" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
@@ -29,6 +29,53 @@
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
         </Container>
+      </SubComponents>
+    </Container>
+    <Container class="javax.swing.JPanel" name="jPanelGenericFilters">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+      <SubComponents>
+        <Component class="javax.swing.JCheckBox" name="jCheckBoxWVEnable">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="wavelength range"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxWVEnableActionPerformed"/>
+          </Events>
+        </Component>
+        <Component class="javax.swing.JFormattedTextField" name="jFormattedTextFieldWVMin">
+          <Properties>
+            <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
+              <Format format="0.000E0" subtype="-1" type="0"/>
+            </Property>
+            <Property name="text" type="java.lang.String" value="1.000E-6"/>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[80, 27]"/>
+            </Property>
+          </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jFormattedTextFieldWVMinPropertyChange"/>
+          </Events>
+        </Component>
+        <Component class="javax.swing.JFormattedTextField" name="jFormattedTextFieldWVMax">
+          <Properties>
+            <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
+              <Format format="0.000E0" subtype="-1" type="0"/>
+            </Property>
+            <Property name="text" type="java.lang.String" value="2.000E-6"/>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[80, 27]"/>
+            </Property>
+          </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jFormattedTextFieldWVMaxPropertyChange"/>
+          </Events>
+        </Component>
       </SubComponents>
     </Container>
   </SubComponents>

--- a/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.form
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.form
@@ -34,47 +34,58 @@
     <Container class="javax.swing.JPanel" name="jPanelGenericFilters">
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
 
-      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
       <SubComponents>
         <Component class="javax.swing.JCheckBox" name="jCheckBoxWVEnable">
           <Properties>
-            <Property name="text" type="java.lang.String" value="wavelength range"/>
+            <Property name="text" type="java.lang.String" value="EFF_WAVE"/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jCheckBoxWVEnableActionPerformed"/>
           </Events>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
         </Component>
         <Component class="javax.swing.JFormattedTextField" name="jFormattedTextFieldWVMin">
           <Properties>
+            <Property name="columns" type="int" value="8"/>
             <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
               <Format format="0.000E0" subtype="-1" type="0"/>
             </Property>
             <Property name="text" type="java.lang.String" value="1.000E-6"/>
-            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[80, 27]"/>
-            </Property>
           </Properties>
           <Events>
             <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jFormattedTextFieldWVMinPropertyChange"/>
           </Events>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="4" insetsBottom="4" insetsRight="4" anchor="10" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
         </Component>
         <Component class="javax.swing.JFormattedTextField" name="jFormattedTextFieldWVMax">
           <Properties>
+            <Property name="columns" type="int" value="8"/>
             <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
               <Format format="0.000E0" subtype="-1" type="0"/>
             </Property>
             <Property name="text" type="java.lang.String" value="2.000E-6"/>
-            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[80, 27]"/>
-            </Property>
           </Properties>
           <Events>
             <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jFormattedTextFieldWVMaxPropertyChange"/>
           </Events>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="4" insetsBottom="4" insetsRight="4" anchor="10" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
         </Component>
       </SubComponents>
     </Container>

--- a/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.form
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.form
@@ -76,7 +76,7 @@
             <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor">
               <Format format="0.000E0" subtype="-1" type="0"/>
             </Property>
-            <Property name="text" type="java.lang.String" value="2.000E-6"/>
+            <Property name="text" type="java.lang.String" value="9.000E-6"/>
           </Properties>
           <Events>
             <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jFormattedTextFieldWVMaxPropertyChange"/>

--- a/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.java
@@ -172,7 +172,6 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
                         // we set the checkbox and the text fields.
                         // indeed the last wavelength generic filter will be the only one actually used.
                         // the GUI currently has strictly exactly one wavelength generic filter.
-
                         jCheckBoxWVEnable.setSelected(genericFilter.isEnabled());
 
                         for (Range range : genericFilter.getAcceptedRanges()) {
@@ -526,8 +525,7 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
                 // add the generic filter to the subset definition copy
                 subsetCopy.getGenericFilters().add(wvFilter);
                 logger.info("Set GenericFilter wavelength {} {} enabled={}.", wvMin, wvMax, wvEnable);
-            }
-            else {
+            } else {
                 logger.info("Cannot set Wavelength generic Filter because null values.");
             }
 
@@ -613,37 +611,48 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
         gridBagConstraints.weighty = 1.0;
         add(jScrollPane, gridBagConstraints);
 
-        jCheckBoxWVEnable.setText("wavelength range");
+        jPanelGenericFilters.setLayout(new java.awt.GridBagLayout());
+
+        jCheckBoxWVEnable.setText("EFF_WAVE");
         jCheckBoxWVEnable.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jCheckBoxWVEnableActionPerformed(evt);
             }
         });
-        jPanelGenericFilters.add(jCheckBoxWVEnable);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        jPanelGenericFilters.add(jCheckBoxWVEnable, gridBagConstraints);
 
+        jFormattedTextFieldWVMin.setColumns(8);
         jFormattedTextFieldWVMin.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("0.000E0"))));
         jFormattedTextFieldWVMin.setText("1.000E-6");
-        jFormattedTextFieldWVMin.setPreferredSize(new java.awt.Dimension(80, 27));
         jFormattedTextFieldWVMin.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
             public void propertyChange(java.beans.PropertyChangeEvent evt) {
                 jFormattedTextFieldWVMinPropertyChange(evt);
             }
         });
-        jPanelGenericFilters.add(jFormattedTextFieldWVMin);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new java.awt.Insets(4, 4, 4, 4);
+        jPanelGenericFilters.add(jFormattedTextFieldWVMin, gridBagConstraints);
 
+        jFormattedTextFieldWVMax.setColumns(8);
         jFormattedTextFieldWVMax.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("0.000E0"))));
         jFormattedTextFieldWVMax.setText("2.000E-6");
-        jFormattedTextFieldWVMax.setPreferredSize(new java.awt.Dimension(80, 27));
         jFormattedTextFieldWVMax.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
             public void propertyChange(java.beans.PropertyChangeEvent evt) {
                 jFormattedTextFieldWVMaxPropertyChange(evt);
             }
         });
-        jPanelGenericFilters.add(jFormattedTextFieldWVMax);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new java.awt.Insets(4, 4, 4, 4);
+        jPanelGenericFilters.add(jFormattedTextFieldWVMax, gridBagConstraints);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         add(jPanelGenericFilters, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
 

--- a/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.java
@@ -174,7 +174,8 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
                         // the GUI currently has strictly exactly one wavelength generic filter.
                         jCheckBoxWVEnable.setSelected(genericFilter.isEnabled());
 
-                        for (Range range : genericFilter.getAcceptedRanges()) {
+                        if (!genericFilter.getAcceptedRanges().isEmpty()) {
+                            final Range range = genericFilter.getAcceptedRanges().get(0);
                             jFormattedTextFieldWVMin.setText(NumberUtils.format(range.getMin()));
                             jFormattedTextFieldWVMax.setText(NumberUtils.format(range.getMax()));
                         }
@@ -510,23 +511,24 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
             subsetCopy.getGenericFilters().clear();
 
             // register the filter only if the parsed double values are not null
-            if ((wvMin != null) && (wvMax != null)) {
-
+            if ((wvMin != null) || (wvMax != null)) {
                 // create a wavelength generic filter with the values from the GUI
                 final GenericFilter wvFilter = new GenericFilter();
                 wvFilter.setEnabled(wvEnable);
                 wvFilter.setColumnName(COLUMN_EFF_WAVE);
                 wvFilter.setDataType(DataType.NUMERIC);
+
                 final fr.jmmc.oiexplorer.core.model.plot.Range range = new fr.jmmc.oiexplorer.core.model.plot.Range();
-                range.setMin(wvMin);
-                range.setMax(wvMax);
+                range.setMin((wvMin != null) ? wvMin : Double.NaN);
+                range.setMax((wvMax != null) ? wvMax : Double.NaN);
                 wvFilter.getAcceptedRanges().add(range);
 
                 // add the generic filter to the subset definition copy
                 subsetCopy.getGenericFilters().add(wvFilter);
-                logger.info("Set GenericFilter wavelength {} {} enabled={}.", wvMin, wvMax, wvEnable);
-            } else {
-                logger.info("Cannot set Wavelength generic Filter because null values.");
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Set GenericFilter wavelength {} {} enabled={}.", wvMin, wvMax, wvEnable);
+                }
             }
 
             // ask to update the current SubsetDefinition
@@ -657,11 +659,15 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
     }// </editor-fold>//GEN-END:initComponents
 
     private void jFormattedTextFieldWVMinPropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jFormattedTextFieldWVMinPropertyChange
-        processGenericFilters();
+        if ("value".equals(evt.getPropertyName())) {
+            processGenericFilters();
+        }
     }//GEN-LAST:event_jFormattedTextFieldWVMinPropertyChange
 
     private void jFormattedTextFieldWVMaxPropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jFormattedTextFieldWVMaxPropertyChange
-        processGenericFilters();
+        if ("value".equals(evt.getPropertyName())) {
+            processGenericFilters();
+        }
     }//GEN-LAST:event_jFormattedTextFieldWVMaxPropertyChange
 
     private void jCheckBoxWVEnableActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBoxWVEnableActionPerformed

--- a/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.java
@@ -640,7 +640,7 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
 
         jFormattedTextFieldWVMax.setColumns(8);
         jFormattedTextFieldWVMax.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.NumberFormatter(new java.text.DecimalFormat("0.000E0"))));
-        jFormattedTextFieldWVMax.setText("2.000E-6");
+        jFormattedTextFieldWVMax.setText("9.000E-6");
         jFormattedTextFieldWVMax.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
             public void propertyChange(java.beans.PropertyChangeEvent evt) {
                 jFormattedTextFieldWVMaxPropertyChange(evt);
@@ -907,33 +907,5 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
             }
             return sb.toString();
         }
-    }
-
-    public static JFormattedTextField.AbstractFormatterFactory getDecimalFormatterFactory() {
-        return new DefaultFormatterFactory(new NumberFormatter(new DecimalFormat("0.0####E00")) {
-            private static final long serialVersionUID = 1L;
-
-            private final NumberFormat fmtDef = new DecimalFormat("0.0####");
-
-            @Override
-            public String valueToString(final Object value) throws ParseException {
-                if (value == null) {
-                    return "";
-                }
-                if (value instanceof Double) {
-                    // check value range:
-                    final double abs = Math.abs((Double) value);
-
-                    if ((abs > 1e-3d) && (abs < 1e3d)) {
-                        return fmtDef.format(value);
-                    }
-                }
-                final String formatted = super.valueToString(value);
-                if (formatted.endsWith("E00")) {
-                    return formatted.substring(0, formatted.length() - 3);
-                }
-                return formatted;
-            }
-        });
     }
 }

--- a/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/DataTreePanel.java
@@ -14,11 +14,14 @@ import fr.jmmc.oiexplorer.core.model.OIFitsCollectionManagerEventListener;
 import fr.jmmc.oiexplorer.core.model.OIFitsCollectionManagerEventType;
 import static fr.jmmc.oiexplorer.core.model.OIFitsCollectionManagerEventType.ACTIVE_PLOT_CHANGED;
 import static fr.jmmc.oiexplorer.core.model.OIFitsCollectionManagerEventType.COLLECTION_CHANGED;
+import fr.jmmc.oiexplorer.core.model.oi.DataType;
+import fr.jmmc.oiexplorer.core.model.oi.GenericFilter;
 import fr.jmmc.oiexplorer.core.model.oi.OIDataFile;
 import fr.jmmc.oiexplorer.core.model.oi.Plot;
 import fr.jmmc.oiexplorer.core.model.oi.SubsetDefinition;
 import fr.jmmc.oiexplorer.core.model.oi.SubsetFilter;
 import fr.jmmc.oiexplorer.core.model.oi.TableUID;
+import static fr.jmmc.oitools.OIFitsConstants.COLUMN_EFF_WAVE;
 import fr.jmmc.oitools.model.Granule;
 import fr.jmmc.oitools.model.InstrumentMode;
 import fr.jmmc.oitools.model.InstrumentModeManager;
@@ -449,6 +452,18 @@ public final class DataTreePanel extends javax.swing.JPanel implements TreeSelec
                     }
                 }
             }
+
+            // TODO: remove this hardcoded generic filter, replace by GUI widget
+            final GenericFilter wvFilter = new GenericFilter();
+            wvFilter.setEnabled(true);
+            wvFilter.setColumnName(COLUMN_EFF_WAVE);
+            wvFilter.setDataType(DataType.NUMERIC);
+            final fr.jmmc.oiexplorer.core.model.plot.Range range = new fr.jmmc.oiexplorer.core.model.plot.Range();
+            range.setMin(1.9E-6);
+            range.setMax(2.3E-6);
+            wvFilter.getAcceptedRanges().add(range);
+            subsetCopy.getGenericFilters().clear();
+            subsetCopy.getGenericFilters().add(wvFilter);
 
             // fire subset changed event:
             ocm.updateSubsetDefinition(this, subsetCopy);

--- a/src/main/java/fr/jmmc/oiexplorer/gui/OIFitsFileListPanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/OIFitsFileListPanel.java
@@ -19,7 +19,6 @@ import fr.jmmc.oiexplorer.core.model.oi.Plot;
 import fr.jmmc.oiexplorer.core.model.oi.SubsetDefinition;
 import fr.jmmc.oitools.model.OIFitsCollection;
 import fr.jmmc.oitools.model.OIFitsFile;
-import fr.jmmc.oitools.model.OITable;
 import java.awt.Component;
 import java.awt.event.MouseEvent;
 import java.lang.ref.WeakReference;
@@ -177,12 +176,12 @@ public class OIFitsFileListPanel extends javax.swing.JPanel implements OIFitsCol
 
         final SubsetDefinition subset = getSubsetDefinitionRef();
         // ignore for non valid oifitsSubset associated
-        if (subset == null || subset.getOIFitsSubset() == null) {
+        if (subset == null || subset.getSelectorResult()== null) {
             return;
         }
 
         // select element present in both lists
-        final List<OITable> oiFitsOfSubset = subset.getOIFitsSubset().getOITableList();
+        final List<OIFitsFile> oiFitsOfSubset = subset.getSelectorResult().getSortedOIFitsFiles();
         oifitsFileList.clearSelection();
 
         final ListSelectionModel sm = oifitsFileList.getSelectionModel();
@@ -190,8 +189,8 @@ public class OIFitsFileListPanel extends javax.swing.JPanel implements OIFitsCol
 
         int found = -1;
         for (int i = 0; i < size; i++) {
-            for (OITable table : oiFitsOfSubset) {
-                if (table.getOIFitsFile() == lm.getElementAt(i)) {
+            for (OIFitsFile oiFitsFile : oiFitsOfSubset) {
+                if (oiFitsFile == lm.getElementAt(i)) {
                     sm.addSelectionInterval(i, i);
                     if (found == -1) {
                         found = i;

--- a/src/main/resources/fr/jmmc/oiexplorer/resource/ApplicationData.xml
+++ b/src/main/resources/fr/jmmc/oiexplorer/resource/ApplicationData.xml
@@ -15,8 +15,8 @@
         <feedback_form_url>http://jmmc.fr/feedback/feedback.php</feedback_form_url>
     </company>
 
-    <program name="OIFitsExplorer" version="0.3.0 beta 5"/>
-    <compilation date="17/06/2022" compiler="JDK 1.8.0"/>
+    <program name="OIFitsExplorer" version="0.3.0 beta 6"/>
+    <compilation date="30/06/2022" compiler="JDK 1.8.0"/>
 
     <text>OIFitsExplorer is the JMMC tool to explore your interferometric observation reduced data as OIFits files.</text>
 
@@ -169,7 +169,10 @@
 
     <releasenotes>
         <release version="0.3.0">
-            <pubDate>Fri, 17 Jun 2022 17:00:00 GMT</pubDate>
+            <pubDate>Thu, 30 Jun 2022 16:00:00 GMT</pubDate>
+            <prerelease version="0.3.0 beta 6">
+               <change type="FEATURE" url="https://github.com/JMMC-OpenDev/oiexplorer/issues/11">Added new dynamic filter on wavelength (only 1 range for now)</change>
+            </prerelease>
             <prerelease version="0.3.0 beta 5">
                <change type="BUGFIX">Added XML Model view in dev mode (-Doixp.devMode=true)</change>
                <change type="BUGFIX">Always remove all views when clicking on 'New OIFits Collection' action</change>


### PR DESCRIPTION
Related to https://github.com/JMMC-OpenDev/oiexplorer/issues/11

!! not ready to be merged yet !!

- adds swing elts for a wavelength range
- reacts to changes in these swing elts by creating a generic filter and setting it in current subset definition
- reacts to changes in collection by modifying swing elts. 
  - it always display swing elts for one wavelength range, no matter if the loaded collection had filters or not