### PR TITLE
generic filters update

### DIFF
--- a/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.form
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.form
@@ -20,11 +20,57 @@
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
     <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,44,0,0,1,-112"/>
   </AuxValues>
+
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
   <SubComponents>
-    <Container class="javax.swing.JScrollPane" name="jScrollPane1">
+    <Container class="javax.swing.JPanel" name="jPanelToolbar">
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.9" weightY="0.9"/>
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
+      <SubComponents>
+        <Component class="javax.swing.JButton" name="jButtonAddGenericFilter">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="+"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButtonAddGenericFilterActionPerformed"/>
+          </Events>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JComboBox" name="jComboBoxColumnName">
+          <Properties>
+            <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+              <StringArray count="1">
+                <StringItem index="0" value="COLUMN_NAME"/>
+              </StringArray>
+            </Property>
+            <Property name="prototypeDisplayValue" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="&quot;XXXX&quot;" type="code"/>
+            </Property>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+          </AuxValues>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="10" weightX="0.8" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+      </SubComponents>
+    </Container>
+    <Container class="javax.swing.JScrollPane" name="jScrollPaneFilters">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.9" weightY="0.9"/>
         </Constraint>
       </Constraints>
 
@@ -38,257 +84,5 @@
         </Container>
       </SubComponents>
     </Container>
-    <Component class="javax.swing.JButton" name="jButtonAddGenericFilter">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="+"/>
-      </Properties>
-      <Events>
-        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButtonAddGenericFilterActionPerformed"/>
-      </Events>
-      <Constraints>
-        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="2" insetsLeft="2" insetsBottom="2" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
-        </Constraint>
-      </Constraints>
-    </Component>
   </SubComponents>
-  <LayoutCode>
-    <CodeStatement>
-      <CodeExpression id="1_layout">
-        <CodeVariable name="layout" type="4096" declaredType="java.awt.GridBagLayout"/>
-        <ExpressionOrigin>
-          <ExpressionProvider type="CodeConstructor">
-            <CodeConstructor class="java.awt.GridBagLayout" parameterTypes=""/>
-          </ExpressionProvider>
-        </ExpressionOrigin>
-      </CodeExpression>
-      <StatementProvider type="CodeExpression">
-        <CodeExpression id="1_layout"/>
-      </StatementProvider>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="1_layout"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="columnWidths" class="java.awt.GridBagLayout"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="2">
-          <ExpressionOrigin>
-            <Value type="[I" editor="org.netbeans.modules.form.layoutsupport.delegates.GridBagLayoutSupport$IntArrayPropertyEditor">
-              <PropertyValue value="[0, 10, 0]"/>
-            </Value>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="1_layout"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="rowHeights" class="java.awt.GridBagLayout"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="3">
-          <ExpressionOrigin>
-            <Value type="[I" editor="org.netbeans.modules.form.layoutsupport.delegates.GridBagLayoutSupport$IntArrayPropertyEditor">
-              <PropertyValue value="[0, 7, 0]"/>
-            </Value>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="4">
-        <ExpressionOrigin>
-          <ExpressionProvider type="ComponentRef">
-            <ComponentRef name="."/>
-          </ExpressionProvider>
-        </ExpressionOrigin>
-      </CodeExpression>
-      <StatementProvider type="CodeMethod">
-        <CodeMethod name="setLayout" class="java.awt.Container" parameterTypes="java.awt.LayoutManager"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="1_layout"/>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="5_gridBagConstraints">
-        <CodeVariable name="gridBagConstraints" type="20480" declaredType="java.awt.GridBagConstraints"/>
-        <ExpressionOrigin>
-          <ExpressionProvider type="CodeConstructor">
-            <CodeConstructor class="java.awt.GridBagConstraints" parameterTypes=""/>
-          </ExpressionProvider>
-        </ExpressionOrigin>
-      </CodeExpression>
-      <StatementProvider type="CodeExpression">
-        <CodeExpression id="5_gridBagConstraints"/>
-      </StatementProvider>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="5_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="gridx" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="6">
-          <ExpressionOrigin>
-            <Value type="int" value="0"/>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="5_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="gridy" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="7">
-          <ExpressionOrigin>
-            <Value type="int" value="2"/>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="5_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="fill" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="8">
-          <ExpressionOrigin>
-            <Value type="int" value="1"/>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="5_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="weightx" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="9">
-          <ExpressionOrigin>
-            <Value type="double" value="0.9"/>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="5_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="weighty" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="10">
-          <ExpressionOrigin>
-            <Value type="double" value="0.9"/>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="4"/>
-      <StatementProvider type="CodeMethod">
-        <CodeMethod name="add" class="java.awt.Container" parameterTypes="java.awt.Component, java.lang.Object"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="11_jScrollPane1">
-          <CodeVariable name="jScrollPane1" type="8194" declaredType="javax.swing.JScrollPane"/>
-          <ExpressionOrigin>
-            <ExpressionProvider type="ComponentRef">
-              <ComponentRef name="jScrollPane1"/>
-            </ExpressionProvider>
-          </ExpressionOrigin>
-        </CodeExpression>
-        <CodeExpression id="5_gridBagConstraints"/>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="12_gridBagConstraints">
-        <CodeVariable name="gridBagConstraints"/>
-        <ExpressionOrigin>
-          <ExpressionProvider type="CodeConstructor">
-            <CodeConstructor class="java.awt.GridBagConstraints" parameterTypes=""/>
-          </ExpressionProvider>
-        </ExpressionOrigin>
-      </CodeExpression>
-      <StatementProvider type="CodeExpression">
-        <CodeExpression id="12_gridBagConstraints"/>
-      </StatementProvider>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="12_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="gridx" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="13">
-          <ExpressionOrigin>
-            <Value type="int" value="0"/>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="12_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="gridy" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="14">
-          <ExpressionOrigin>
-            <Value type="int" value="0"/>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="12_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="anchor" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="15">
-          <ExpressionOrigin>
-            <Value type="int" value="17"/>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="12_gridBagConstraints"/>
-      <StatementProvider type="CodeField">
-        <CodeField name="insets" class="java.awt.GridBagConstraints"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="16">
-          <ExpressionOrigin>
-            <Value type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-              <Insets value="[2, 2, 2, 2]"/>
-            </Value>
-          </ExpressionOrigin>
-        </CodeExpression>
-      </Parameters>
-    </CodeStatement>
-    <CodeStatement>
-      <CodeExpression id="4"/>
-      <StatementProvider type="CodeMethod">
-        <CodeMethod name="add" class="java.awt.Container" parameterTypes="java.awt.Component, java.lang.Object"/>
-      </StatementProvider>
-      <Parameters>
-        <CodeExpression id="17_jButtonAddGenericFilter">
-          <CodeVariable name="jButtonAddGenericFilter" type="8194" declaredType="javax.swing.JButton"/>
-          <ExpressionOrigin>
-            <ExpressionProvider type="ComponentRef">
-              <ComponentRef name="jButtonAddGenericFilter"/>
-            </ExpressionProvider>
-          </ExpressionOrigin>
-        </CodeExpression>
-        <CodeExpression id="12_gridBagConstraints"/>
-      </Parameters>
-    </CodeStatement>
-  </LayoutCode>
 </Form>

--- a/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
@@ -14,9 +14,8 @@ import fr.jmmc.oiexplorer.core.model.oi.GenericFilter;
 import fr.jmmc.oiexplorer.core.model.oi.Identifiable;
 import fr.jmmc.oiexplorer.core.model.oi.SubsetDefinition;
 import fr.jmmc.oiexplorer.core.model.plot.Range;
-import fr.jmmc.oitools.OIFitsConstants;
-import static fr.jmmc.oitools.OIFitsConstants.COLUMN_EFF_WAVE;
 import fr.jmmc.oitools.model.DataModel;
+import fr.jmmc.oitools.processing.Selector;
 import fr.jmmc.oitools.processing.SelectorResult;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -47,9 +46,13 @@ public class GenericFiltersPanel extends javax.swing.JPanel
     private final static OIFitsCollectionManager OCM = OIFitsCollectionManager.getInstance();
 
     private static final List<String> SPECIAL_COLUMN_NAMES = Arrays.asList(new String[]{
-        OIFitsConstants.COLUMN_EFF_WAVE,
-        OIFitsConstants.COLUMN_EFF_BAND}
-    );
+        Selector.FILTER_EFFWAVE,
+        Selector.FILTER_EFFBAND, /* uncomment once supported (String values)
+        /*
+        Selector.FILTER_NIGHT_ID, 
+        Selector.FILTER_STAINDEX,
+        Selector.FILTER_STACONF
+     */});
 
     /** List of GenericFilterEditor for each GenericFilter in the current SubsetDefinition */
     private final List<GenericFilterEditor> genericFilterEditorList;
@@ -180,7 +183,7 @@ public class GenericFiltersPanel extends javax.swing.JPanel
 
             String columnName = (String) jComboBoxColumnName.getSelectedItem();
             if (columnName == null) {
-                columnName = COLUMN_EFF_WAVE;
+                columnName = Selector.FILTER_EFFWAVE;
             }
 
             final fr.jmmc.oitools.model.range.Range oitoolsRange = OCM.getOIFitsCollection().getColumnRange(columnName);

--- a/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
@@ -173,13 +173,20 @@ public class GenericFiltersPanel extends javax.swing.JPanel
                 columnName = COLUMN_EFF_WAVE;
             }
 
+            final fr.jmmc.oitools.model.range.Range oitoolsRange = OCM.getOIFitsCollection().getMinMaxRange(columnName);
+            final Range range = new Range();
+            if (oitoolsRange == null) {
+                range.setMin(Double.NaN);
+                range.setMax(Double.NaN);
+            } else {
+                range.setMin(oitoolsRange.getMin());
+                range.setMax(oitoolsRange.getMax());
+            }
+
             GenericFilter newGenericFilter = new GenericFilter();
             newGenericFilter.setEnabled(true);
             newGenericFilter.setColumnName(columnName);
             newGenericFilter.setDataType(DataType.NUMERIC);
-            final Range range = new Range();
-            range.setMin(Double.NaN);
-            range.setMax(Double.NaN);
             newGenericFilter.getAcceptedRanges().add(range);
 
             addGenericFilterEditor(newGenericFilter);

--- a/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
@@ -18,13 +18,15 @@ import fr.jmmc.oitools.OIFitsConstants;
 import static fr.jmmc.oitools.OIFitsConstants.COLUMN_EFF_WAVE;
 import fr.jmmc.oitools.model.DataModel;
 import fr.jmmc.oitools.processing.SelectorResult;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.event.ChangeEvent;
@@ -144,8 +146,9 @@ public class GenericFiltersPanel extends javax.swing.JPanel
     /** Adds a GenericFilterEditor to the Panel, along with a delete button */
     private boolean addGenericFilterEditor(final GenericFilter genericFilter) {
 
-        final JPanel panel = new JPanel();
-        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        final JPanel panel = new JPanel(new GridBagLayout());
+
+        final GridBagConstraints layoutConsts = new GridBagConstraints();
 
         final GenericFilterEditor newGenericFilterEditor = new GenericFilterEditor();
         newGenericFilterEditor.addChangeListener(this);
@@ -153,11 +156,18 @@ public class GenericFiltersPanel extends javax.swing.JPanel
         final boolean modified = newGenericFilterEditor.setGenericFilter(genericFilter);
 
         genericFilterEditorList.add(newGenericFilterEditor);
-        panel.add(newGenericFilterEditor);
+        layoutConsts.gridx = 0;
+        layoutConsts.fill = GridBagConstraints.HORIZONTAL;
+        layoutConsts.weightx = 0.9;
+        panel.add(newGenericFilterEditor, layoutConsts);
 
         final JButton delButton = new JButton("-");
         delButton.addActionListener(this);
-        panel.add(delButton);
+        layoutConsts.gridx = 1;
+        layoutConsts.fill = GridBagConstraints.NONE;
+        layoutConsts.weightx = 0;
+        layoutConsts.insets = new Insets(2, 2, 2, 2);
+        panel.add(delButton, layoutConsts);
 
         jPanelGenericFilters.add(panel, 0);
 

--- a/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
@@ -183,7 +183,7 @@ public class GenericFiltersPanel extends javax.swing.JPanel
                 columnName = COLUMN_EFF_WAVE;
             }
 
-            final fr.jmmc.oitools.model.range.Range oitoolsRange = OCM.getOIFitsCollection().getMinMaxRange(columnName);
+            final fr.jmmc.oitools.model.range.Range oitoolsRange = OCM.getOIFitsCollection().getColumnRange(columnName);
             final Range range = new Range();
             if (oitoolsRange == null) {
                 range.setMin(Double.NaN);

--- a/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
+++ b/src/main/java/fr/jmmc/oiexplorer/gui/GenericFiltersPanel.java
@@ -3,6 +3,7 @@
  ***************************************************************************** */
 package fr.jmmc.oiexplorer.gui;
 
+import fr.jmmc.jmcs.gui.component.GenericListModel;
 import fr.jmmc.oiexplorer.core.gui.GenericFilterEditor;
 import fr.jmmc.oiexplorer.core.model.OIFitsCollectionManager;
 import fr.jmmc.oiexplorer.core.model.OIFitsCollectionManagerEvent;
@@ -13,11 +14,16 @@ import fr.jmmc.oiexplorer.core.model.oi.GenericFilter;
 import fr.jmmc.oiexplorer.core.model.oi.Identifiable;
 import fr.jmmc.oiexplorer.core.model.oi.SubsetDefinition;
 import fr.jmmc.oiexplorer.core.model.plot.Range;
+import fr.jmmc.oitools.OIFitsConstants;
 import static fr.jmmc.oitools.OIFitsConstants.COLUMN_EFF_WAVE;
+import fr.jmmc.oitools.model.DataModel;
 import fr.jmmc.oitools.processing.SelectorResult;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JPanel;
@@ -38,8 +44,16 @@ public class GenericFiltersPanel extends javax.swing.JPanel
     /** OIFitsCollectionManager singleton reference */
     private final static OIFitsCollectionManager OCM = OIFitsCollectionManager.getInstance();
 
+    private static final List<String> SPECIAL_COLUMN_NAMES = Arrays.asList(new String[]{
+        OIFitsConstants.COLUMN_EFF_WAVE,
+        OIFitsConstants.COLUMN_EFF_BAND}
+    );
+
     /** List of GenericFilterEditor for each GenericFilter in the current SubsetDefinition */
     private final List<GenericFilterEditor> genericFilterEditorList;
+
+    /** Store all column choices available */
+    private final List<String> columnChoices = new LinkedList<String>();
 
     /** when true, disables handler of Changes set on GenericFilterEditors. Used in updateGUI(). */
     private boolean updatingGUI = false;
@@ -49,6 +63,7 @@ public class GenericFiltersPanel extends javax.swing.JPanel
         logger.debug("creates GenericFiltersPanel");
         initComponents();
         genericFilterEditorList = new ArrayList<>(1);
+        jComboBoxColumnName.setModel(new GenericListModel<String>(columnChoices, true));
         OCM.getSubsetDefinitionChangedEventNotifier().register(this);
     }
 
@@ -89,6 +104,9 @@ public class GenericFiltersPanel extends javax.swing.JPanel
             genericFilterEditorList.forEach(GenericFilterEditor::dispose);
             genericFilterEditorList.clear();
 
+            // we clear and recreate column name choices
+            columnChoices.clear();
+
             final SubsetDefinition subsetDefinitionCopy = OCM.getCurrentSubsetDefinition();
 
             if (subsetDefinitionCopy != null) {
@@ -98,7 +116,18 @@ public class GenericFiltersPanel extends javax.swing.JPanel
                 final SelectorResult selectorResult = subsetDefinitionCopy.getSelectorResult();
 
                 for (GenericFilter genericFilter : subsetDefinitionCopy.getGenericFilters()) {
-                    changed |= addGenericFilterEditor(selectorResult, genericFilter);
+                    changed |= addGenericFilterEditor(genericFilter);
+                }
+
+                // updating column choices from SelectorResult
+                for (String specialName : SPECIAL_COLUMN_NAMES) {
+                    columnChoices.add(specialName);
+                }
+                for (String columnName : getDistinctColumns1D(selectorResult)) {
+                    columnChoices.add(columnName);
+                }
+                if (jComboBoxColumnName.getSelectedIndex() == -1) {
+                    jComboBoxColumnName.setSelectedIndex(0);
                 }
 
                 if (changed) { // if some generic filters have been modified, submit the changes to the model
@@ -113,7 +142,7 @@ public class GenericFiltersPanel extends javax.swing.JPanel
     }
 
     /** Adds a GenericFilterEditor to the Panel, along with a delete button */
-    private boolean addGenericFilterEditor(final SelectorResult selectorResult, final GenericFilter genericFilter) {
+    private boolean addGenericFilterEditor(final GenericFilter genericFilter) {
 
         final JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
@@ -121,7 +150,7 @@ public class GenericFiltersPanel extends javax.swing.JPanel
         final GenericFilterEditor newGenericFilterEditor = new GenericFilterEditor();
         newGenericFilterEditor.addChangeListener(this);
 
-        final boolean modified = newGenericFilterEditor.setGenericFilter(selectorResult, genericFilter);
+        final boolean modified = newGenericFilterEditor.setGenericFilter(genericFilter);
 
         genericFilterEditorList.add(newGenericFilterEditor);
         panel.add(newGenericFilterEditor);
@@ -139,19 +168,21 @@ public class GenericFiltersPanel extends javax.swing.JPanel
     private void handlerAddGenericFilter() {
         if (!updatingGUI) {
 
+            String columnName = (String) jComboBoxColumnName.getSelectedItem();
+            if (columnName == null) {
+                columnName = COLUMN_EFF_WAVE;
+            }
+
             GenericFilter newGenericFilter = new GenericFilter();
             newGenericFilter.setEnabled(true);
-            newGenericFilter.setColumnName(COLUMN_EFF_WAVE);
+            newGenericFilter.setColumnName(columnName);
             newGenericFilter.setDataType(DataType.NUMERIC);
             final Range range = new Range();
             range.setMin(Double.NaN);
             range.setMax(Double.NaN);
             newGenericFilter.getAcceptedRanges().add(range);
 
-            final SubsetDefinition subsetDefinitionCopy = OCM.getCurrentSubsetDefinition();
-            final SelectorResult selectorResult = subsetDefinitionCopy.getSelectorResult();
-
-            addGenericFilterEditor(selectorResult, newGenericFilter);
+            addGenericFilterEditor(newGenericFilter);
 
             revalidate();
 
@@ -229,6 +260,19 @@ public class GenericFiltersPanel extends javax.swing.JPanel
     }
 
     /**
+     * Return the set of distinct columns available in tables of the given SelectorResult.
+     *
+     * @param selectorResult Selector result from plot's subset definition
+     * @return a Set of Strings with every distinct column names
+     */
+    private static Set<String> getDistinctColumns1D(final SelectorResult selectorResult) {
+        final DataModel dataModel = (selectorResult == null) ? DataModel.getInstance() : selectorResult.getDataModel();
+        logger.debug("datamodel : {}", dataModel);
+
+        return dataModel.getNumericalColumnNames1D();
+    }
+
+    /**
      * This method is called from within the constructor to initialize the form. WARNING: Do NOT modify this code. The
      * content of this method is always regenerated by the Form Editor.
      */
@@ -237,26 +281,16 @@ public class GenericFiltersPanel extends javax.swing.JPanel
     private void initComponents() {
         java.awt.GridBagConstraints gridBagConstraints;
 
-        jScrollPane1 = new javax.swing.JScrollPane();
-        jPanelGenericFilters = new javax.swing.JPanel();
+        jPanelToolbar = new javax.swing.JPanel();
         jButtonAddGenericFilter = new javax.swing.JButton();
+        jComboBoxColumnName = new javax.swing.JComboBox<>();
+        jScrollPaneFilters = new javax.swing.JScrollPane();
+        jPanelGenericFilters = new javax.swing.JPanel();
 
         setBorder(javax.swing.BorderFactory.createTitledBorder("Generic Filters"));
-        java.awt.GridBagLayout layout = new java.awt.GridBagLayout();
-        layout.columnWidths = new int[] {0, 10, 0};
-        layout.rowHeights = new int[] {0, 7, 0};
-        setLayout(layout);
+        setLayout(new java.awt.GridBagLayout());
 
-        jPanelGenericFilters.setLayout(new javax.swing.BoxLayout(jPanelGenericFilters, javax.swing.BoxLayout.Y_AXIS));
-        jScrollPane1.setViewportView(jPanelGenericFilters);
-
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 2;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 0.9;
-        gridBagConstraints.weighty = 0.9;
-        add(jScrollPane1, gridBagConstraints);
+        jPanelToolbar.setLayout(new java.awt.GridBagLayout());
 
         jButtonAddGenericFilter.setText("+");
         jButtonAddGenericFilter.addActionListener(new java.awt.event.ActionListener() {
@@ -267,9 +301,33 @@ public class GenericFiltersPanel extends javax.swing.JPanel
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
-        add(jButtonAddGenericFilter, gridBagConstraints);
+        jPanelToolbar.add(jButtonAddGenericFilter, gridBagConstraints);
+
+        jComboBoxColumnName.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "COLUMN_NAME" }));
+        jComboBoxColumnName.setPrototypeDisplayValue("XXXX");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.weightx = 0.8;
+        gridBagConstraints.insets = new java.awt.Insets(2, 2, 2, 2);
+        jPanelToolbar.add(jComboBoxColumnName, gridBagConstraints);
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        add(jPanelToolbar, gridBagConstraints);
+
+        jPanelGenericFilters.setLayout(new javax.swing.BoxLayout(jPanelGenericFilters, javax.swing.BoxLayout.Y_AXIS));
+        jScrollPaneFilters.setViewportView(jPanelGenericFilters);
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 0.9;
+        gridBagConstraints.weighty = 0.9;
+        add(jScrollPaneFilters, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
 
     private void jButtonAddGenericFilterActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonAddGenericFilterActionPerformed
@@ -278,8 +336,10 @@ public class GenericFiltersPanel extends javax.swing.JPanel
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton jButtonAddGenericFilter;
+    private javax.swing.JComboBox<String> jComboBoxColumnName;
     private javax.swing.JPanel jPanelGenericFilters;
-    private javax.swing.JScrollPane jScrollPane1;
+    private javax.swing.JPanel jPanelToolbar;
+    private javax.swing.JScrollPane jScrollPaneFilters;
     // End of variables declaration//GEN-END:variables
 
 }


### PR DESCRIPTION
- moves the combo box for column name from GenericFilterEditor to GenericFilterPanel
  - so the selection of column name is only at the creation of the generic filter and cannot be changed afterward
- gives initial values to the range of a new generic filter editor by asking to OIFitsCollection (for now it is a fake function, see branch https://github.com/buthanoid/oitools/tree/fake-getminmaxrange)
- grid bag layout for generic filter instead of box layout (it is cleaner)